### PR TITLE
add 'requirement' keyword in default exclude list 

### DIFF
--- a/App.svelte
+++ b/App.svelte
@@ -74,6 +74,10 @@
     required: {
       keywords: ['required'],
       checked: true,
+    },
+    requirement: {
+      keywords: ['requirement'],
+      checked: true
     }
   };
 

--- a/App.svelte
+++ b/App.svelte
@@ -72,12 +72,8 @@
       checked: true,
     },
     required: {
-      keywords: ['required'],
+      keywords: ['required', 'requirement'],
       checked: true,
-    },
-    requirement: {
-      keywords: ['requirement'],
-      checked: true
     }
   };
 


### PR DESCRIPTION
Saw a lot of tweets with `Urgent Requirement` in text which was being ignored by default excludes. 

https://twitter.com/search?q=verified+indore+%28tocilizumab%29+-%22not+verified%22+-%22unverified%22+-%22needed%22+-%22required%22&f=live 

Thanks for building this let me know if I can help with something. 