### PR TITLE
Move generated links on top as that's more useful.

### DIFF
--- a/GeneratedLinksModal.svelte
+++ b/GeneratedLinksModal.svelte
@@ -5,5 +5,5 @@
   export let links;
 </script>
 
-<Tips large={false} />
 <GeneratedLinks {links} />
+<Tips large={false} />


### PR DESCRIPTION
Tips are already present on the landing page, so let's move the generated links on top to make it more accessible.