### PR TITLE
🚑 Add Ambulance in alsoSearchFor check list

### DIFF
--- a/App.svelte
+++ b/App.svelte
@@ -65,7 +65,11 @@
     food: {
       keywords: ["tiffin", "food"],
       checked: false
-    }
+    },
+    ambulance: {
+      keywords: ["ambulance"],
+      checked: false
+    },
   };
   const excludeKeywords = {
     needed: {


### PR DESCRIPTION
## Why add ambulance in check list?

- People are regularly searching for Ambulance phone numbers & adding them in checkmark might be quicker than writing it in Other inputbox.
- People are also tweeting phone numbers of drivers who respond quickly.

![image](https://user-images.githubusercontent.com/21218732/116293927-fcabc700-a7b4-11eb-8695-c756af53f5de.png)

LMK if more changes are required. Thank you for building this life saving tool 🙏🏻